### PR TITLE
Improve terminal node detection in decision tree

### DIFF
--- a/src/components/DecisionTreeNavigator.tsx
+++ b/src/components/DecisionTreeNavigator.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { ArrowLeft, ArrowRight, Home, RotateCcw, CheckCircle, AlertTriangle, Info } from 'lucide-react';
+import { ArrowLeft, ArrowRight, Home, RotateCcw, CheckCircle, Info } from 'lucide-react';
 import { DecisionTree, DecisionNode, NavigationHistory, Device } from '../types';
 
 interface DecisionTreeNavigatorProps {
@@ -39,7 +39,19 @@ export const DecisionTreeNavigator: React.FC<DecisionTreeNavigatorProps> = ({
   };
 
   const isTerminalNode = (node: DecisionNode) => {
-    return node.isTerminal || node.options.some(option => option.solution);
+    if (node.isTerminal) {
+      return true;
+    }
+
+    // Only treat a node as terminal if every option directly provides
+    // a solution. This prevents nodes with mixed options (some leading
+    // to another question and others ending) from being flagged as
+    // terminal.
+    if (!node.options || node.options.length === 0) {
+      return false;
+    }
+
+    return node.options.every((option) => Boolean(option.solution));
   };
 
   return (


### PR DESCRIPTION
## Summary
- Refine terminal node check to require explicit flag or solutions for all options
- Remove unused icon import

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68976424bde483309f0cec3b51aeb6a5