### PR TITLE
Handle missing device ID during procedure import

### DIFF
--- a/src/components/DecisionTreeNavigator.tsx
+++ b/src/components/DecisionTreeNavigator.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { ArrowLeft, ArrowRight, Home, RotateCcw, CheckCircle, AlertTriangle, Info } from 'lucide-react';
+import { ArrowLeft, ArrowRight, Home, RotateCcw, CheckCircle, Info } from 'lucide-react';
 import { DecisionTree, DecisionNode, NavigationHistory, Device } from '../types';
 
 interface DecisionTreeNavigatorProps {

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -165,9 +165,15 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
           return;
         }
 
+        // Ensure a device is selected for import
+        if (!importingDeviceId) {
+          setImportError('No device selected for import.');
+          return;
+        }
+
         // Create the decision tree
         const newDecisionTree: DecisionTree = {
-          deviceId: importingDeviceId!,
+          deviceId: importingDeviceId,
           rootNodeId: parsedData.rootNodeId,
           nodes: parsedData.nodes
         };
@@ -175,7 +181,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
         // Update the decision trees
         const updatedTrees = {
           ...decisionTrees,
-          [importingDeviceId!]: newDecisionTree
+          [importingDeviceId]: newDecisionTree
         };
 
         onUpdateDecisionTrees(updatedTrees);


### PR DESCRIPTION
## Summary
- Validate device ID before importing a decision tree
- Remove non-null assertions when updating decision trees
- Drop unused `AlertTriangle` import to satisfy lint

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npx eslint src/components/SettingsPanel.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68976521d9a88330b2d6d7a00edd3023