### PR TITLE
Add safety checks for localStorage usage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,8 +14,11 @@ const STORAGE_KEYS = {
 };
 
 const loadFromStorage = <T,>(key: string, fallback: T): T => {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return fallback;
+  }
   try {
-    const stored = localStorage.getItem(key);
+    const stored = window.localStorage.getItem(key);
     return stored ? JSON.parse(stored) : fallback;
   } catch (error) {
     console.warn(`Failed to load ${key} from localStorage:`, error);
@@ -24,8 +27,11 @@ const loadFromStorage = <T,>(key: string, fallback: T): T => {
 };
 
 const saveToStorage = <T,>(key: string, data: T): void => {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return;
+  }
   try {
-    localStorage.setItem(key, JSON.stringify(data));
+    window.localStorage.setItem(key, JSON.stringify(data));
   } catch (error) {
     console.warn(`Failed to save ${key} to localStorage:`, error);
   }


### PR DESCRIPTION
## Summary
- Guard storage helpers against missing `window` or `localStorage`
- Skip saving and fallback to defaults when storage isn't available

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897692b3ee48330a3fc485ef7967b6f