### PR TITLE
Configure API proxy in Vite dev server

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,4 +7,10 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
+  server: {
+    proxy: {
+      '/devices': 'http://localhost:3001',
+      '/decision-trees': 'http://localhost:3001',
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- proxy `/devices` and `/decision-trees` requests to the Express server

## Testing
- `npm run lint`
- Started Express server and Vite dev server
- `curl -s http://localhost:5173/devices | jq 'map(.id)'`
- `curl -X DELETE http://localhost:5173/devices/scalp-reader-loreal`
- `curl -s http://localhost:5173/devices | jq 'map(.id)'`


------
https://chatgpt.com/codex/tasks/task_e_6897762c371c8330acfdb7769c9c9fe7