### PR TITLE
Improve device deletion error handling

### DIFF
--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -117,15 +117,24 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     if (confirm('Are you sure you want to delete this device? This will also remove its associated procedures.')) {
       try {
         const res = await fetch(`/devices/${deviceId}`, { method: 'DELETE' });
-        if (res.ok) {
-          const updatedDevices = await res.json();
-          onUpdateDevices(updatedDevices);
+        if (!res.ok) {
+          alert('Failed to delete device');
+          return;
         }
+
+        const updatedDevices = await res.json();
+
         const treeRes = await fetch(`/decision-trees/${deviceId}`, { method: 'DELETE' });
-        if (treeRes.ok) {
-          const updatedTrees = await treeRes.json();
-          onUpdateDecisionTrees(updatedTrees);
+        if (!treeRes.ok) {
+          alert('Failed to delete device procedures');
+          return;
         }
+
+        const updatedTrees = await treeRes.json();
+
+        onUpdateDevices(updatedDevices);
+        onUpdateDecisionTrees(updatedTrees);
+        alert('Device deleted successfully');
       } catch {
         alert('Failed to delete device');
       }


### PR DESCRIPTION
## Summary
- alert if device or procedure deletion fails and stop further updates
- show success message after device and procedures are deleted
- avoid calling decision tree deletion until device deletion succeeds

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689783255cf083308c470feaeac3e2c0