### PR TITLE
Refactor device deletion flow for sequential API calls

### DIFF
--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -117,32 +117,32 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   };
 
   const handleDeleteDevice = async (deviceId: string) => {
-    if (confirm('Are you sure you want to delete this device? This will also remove its associated procedures.')) {
-      try {
-const res = await fetch(`${API_BASE_URL}/devices/${deviceId}`, { method: 'DELETE' });
-if (!res.ok) {
-  alert('Failed to delete device');
-  return;
-}
-const updatedDevices = await res.json();
-onUpdateDevices(updatedDevices);
+    if (!confirm('Are you sure you want to delete this device? This will also remove its associated procedures.')) {
+      return;
+    }
 
-const treeRes = await fetch(`${API_BASE_URL}/decision-trees/${deviceId}`, { method: 'DELETE' });
-if (!treeRes.ok) {
-  alert('Failed to delete device procedures');
-  return;
-}
-const updatedTrees = await treeRes.json();
-onUpdateDecisionTrees(updatedTrees);
+    try {
+      const res = await fetch(`${API_BASE_URL}/devices/${deviceId}`, { method: 'DELETE' });
+      if (!res.ok) {
+        const message = await res.text();
+        throw new Error(message || 'Failed to delete device');
+      }
+      const updatedDevices = await res.json();
+      onUpdateDevices(updatedDevices);
 
-        }
+      const treeRes = await fetch(`${API_BASE_URL}/decision-trees/${deviceId}`, { method: 'DELETE' });
+      if (!treeRes.ok) {
+        const message = await treeRes.text();
+        throw new Error(message || 'Failed to delete device procedures');
+      }
+      const updatedTrees = await treeRes.json();
+      onUpdateDecisionTrees(updatedTrees);
 
-        const updatedTrees = await treeRes.json();
-
-        onUpdateDevices(updatedDevices);
-        onUpdateDecisionTrees(updatedTrees);
-        alert('Device deleted successfully');
-      } catch {
+      alert('Device deleted successfully');
+    } catch (error) {
+      if (error instanceof Error) {
+        alert(error.message);
+      } else {
         alert('Failed to delete device');
       }
     }


### PR DESCRIPTION
## Summary
- streamline device removal logic with a single try/catch
- update device and procedure lists only after successful DELETE requests
- show success message once both deletions complete

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897b480b48c8330adc43fcd072ef5ff